### PR TITLE
Fix release builds

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27396,7 +27396,7 @@ async function run() {
   try {
     let buildCommand = "";
     if (useDebugBuild === "false") {
-      buildCommand = "cargo install --release";
+      buildCommand = "cargo install";
     } else if (useDebugBuild === "true") {
       buildCommand = "cargo install --debug";
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fontc-action",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fontc-action",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fontc-action",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A GitHub Action for the fontc font compiler",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ async function run() {
   try {
     let buildCommand = "";
     if (useDebugBuild === "false") {
-      buildCommand = "cargo install --release";
+      buildCommand = "cargo install";
     } else if (useDebugBuild === "true") {
       buildCommand = "cargo install --debug";
     } else {


### PR DESCRIPTION
Fixes the cargo release build command used when the debug input field is not defined, or is defined as `false`