### PR TITLE
Add verbose fontc version reporting following fontc installation

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -27429,6 +27429,17 @@ async function run() {
     );
   }
 
+  // =====================================
+  // Report installed fontc build version
+  // =====================================
+  try {
+    await exec.exec(`fontc --vv`);
+  } catch (error) {
+    core.setFailed(
+      `fontc-action failed during attempt to report fontc version: ${error.message}`
+    );
+  }
+
   // ==================
   // Build font(s)
   // ==================

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,17 @@ async function run() {
     );
   }
 
+  // =====================================
+  // Report installed fontc build version
+  // =====================================
+  try {
+    await exec.exec(`fontc --vv`);
+  } catch (error) {
+    core.setFailed(
+      `fontc-action failed during attempt to report fontc version: ${error.message}`
+    );
+  }
+
   // ==================
   // Build font(s)
   // ==================


### PR DESCRIPTION
Uses the new `--vv` option added in https://github.com/googlefonts/fontc/pull/590 to report detailed fontc, rustc, and cargo compiler build-time information prior to the font compile execution.